### PR TITLE
Modify cors middleware to apply to top-level routers

### DIFF
--- a/user-rest-service/infrastructure/router/router.go
+++ b/user-rest-service/infrastructure/router/router.go
@@ -49,20 +49,18 @@ func Run() error {
 
 	router := mux.NewRouter()
 
-	// register middleware
-	router.Use(
-		middleware.NewCorsMiddlewareFunc(),
-		middleware.NewAuthMiddlewareFunc(sessionStore),
-	)
+	// Register auth middleware.
+	router.Use(middleware.NewAuthMiddlewareFunc(sessionStore))
 
 	router.HandleFunc("/signup", userHandler.SignUp).Methods(http.MethodPost)
 	router.HandleFunc("/login", userHandler.Login).Methods(http.MethodPost)
 	router.HandleFunc("/logout", userHandler.Logout).Methods(http.MethodDelete)
 	router.HandleFunc("/user", userHandler.FetchLoginUser).Methods(http.MethodGet)
 
+	// Apply cors middleware to top-level router.
 	srv := &http.Server{
 		Addr:    fmt.Sprintf(":%d", config.Env.Server.Port),
-		Handler: router,
+		Handler: middleware.NewCorsMiddlewareFunc()(router),
 	}
 
 	errorCh := make(chan error, 1)


### PR DESCRIPTION
cors middlewareをrouterのトップレベルで適用。

beforeではhandlerごとに受付けるhttp methodを`.Methods(http.MethodDelete, http.MethodOptions)`と`http.MethodOptions`を明示的に記述してやらないと、そもそもhandlerがPreflight request(http.MethodOptions)を受け付けない。

afterのようにcors middlewareをrouterのトップレベルで適用することで、Preflight requestをcorsで確実に処理する。

before: Preflight requestを受け付けない
```
router := mux.NewRouter()

// Register cors middleware.
router.Use(middleware.NewCorsMiddlewareFunc())

router.HandleFunc("/logout", userHandler.Logout).Methods(http.MethodDelete)
```

after: トップレベルで全てのPreflight requestを受け付けて処理する
```
router := mux.NewRouter()

router.HandleFunc("/logout", userHandler.Logout).Methods(http.MethodDelete)

// Apply cors middleware to top-level router.
srv := &http.Server{
	Addr:    fmt.Sprintf(":%d", config.Env.Server.Port),
	Handler: middleware.NewCorsMiddlewareFunc()(router),
}
```